### PR TITLE
Rename 7z to 7zz

### DIFF
--- a/dependencies/7-zip.yaml
+++ b/dependencies/7-zip.yaml
@@ -7,7 +7,7 @@ build-commands:
       make -j ${FLATPAK_BUILDER_N_JOBS} -f ../../cmpl_gcc.mak
       popd
     done
-  - install -Dm755 CPP/7zip/Bundles/Alone2/b/g/7zz   $FLATPAK_DEST/bin/7z
+  - install -Dm755 CPP/7zip/Bundles/Alone2/b/g/7zz   $FLATPAK_DEST/bin/7zz
   - install -Dm755 CPP/7zip/Bundles/SFXCon/b/g/7zCon $FLATPAK_DEST/bin/7zCon.sfx
 
 sources:


### PR DESCRIPTION
KCC v8 has switched from 7z to 7zz on POSIX, I assume this is all that needs to be done.

- https://github.com/ciromattia/kcc/pull/1005

Don't merge until the v8 PR comes in, this is incompatible with v7