### PR TITLE
upgrade to numpy 2

### DIFF
--- a/dependencies/kcc-pypi-dependencies.yaml
+++ b/dependencies/kcc-pypi-dependencies.yaml
@@ -174,7 +174,7 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} --no-build-isolation
+        --prefix=${FLATPAK_DEST} "numpy>1.22.4" --no-build-isolation
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz

--- a/dependencies/kcc-pypi-dependencies.yaml
+++ b/dependencies/kcc-pypi-dependencies.yaml
@@ -174,7 +174,7 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "numpy<2.0.0" --no-build-isolation
+        --prefix=${FLATPAK_DEST} --no-build-isolation
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz
@@ -182,8 +182,6 @@ modules:
         x-checker-data:
           type: pypi
           name: numpy
-          versions:
-            <: 2.0.0
 
     modules:
       - name: pyproject-metadata

--- a/dependencies/kcc-requirements.txt
+++ b/dependencies/kcc-requirements.txt
@@ -8,4 +8,4 @@ packaging>=23.2
 mozjpeg-lossless-optimization>=1.1.2
 natsort>=8.4.0
 distro>=1.8.0
-numpy>=1.22.4,<2.0.0
+numpy>=1.22.4


### PR DESCRIPTION
newer pyside versions gives warning when using old numpy. But it still works I think. KCC main repo uses numpy 2 so may be leaving some optimizations on the table. unless its for compatibility?

- fix #179 

Since I don't use linux I can't test this change though...

Also, pillow should probably be allowed to run newer versions, 

Also pybind might be related idk