### PR TITLE
implement selectively submitting PRs

### DIFF
--- a/dependencies/kcc-pypi-dependencies.yaml
+++ b/dependencies/kcc-pypi-dependencies.yaml
@@ -174,7 +174,7 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} --no-build-isolation
+        --prefix=${FLATPAK_DEST} "numpy>1.22.4" --no-build-isolation
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz

--- a/dependencies/kcc-pypi-dependencies.yaml
+++ b/dependencies/kcc-pypi-dependencies.yaml
@@ -174,7 +174,7 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "numpy<2.0.0" --no-build-isolation
+        --prefix=${FLATPAK_DEST} --no-build-isolation
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz
@@ -182,8 +182,6 @@ modules:
         x-checker-data:
           type: pypi
           name: numpy
-          versions:
-            <: 2.0.0
 
     modules:
       - name: pyproject-metadata

--- a/dependencies/kcc-pypi-dependencies.yaml
+++ b/dependencies/kcc-pypi-dependencies.yaml
@@ -26,8 +26,6 @@ modules:
         x-checker-data:
           type: pypi
           name: Pillow
-          versions:
-            <=: '12.0'
 
   - name: python3-psutil
     buildsystem: simple
@@ -41,8 +39,6 @@ modules:
         x-checker-data:
           type: pypi
           name: psutil
-          versions:
-            <=: '7.0'
 
   - name: python3-python-slugify
     buildsystem: simple
@@ -63,8 +59,6 @@ modules:
         x-checker-data:
           type: pypi
           name: python-slugify
-          versions:
-            <=: '9.0'
 
 
   - name: python3-raven

--- a/dependencies/kcc-pypi-dependencies.yaml
+++ b/dependencies/kcc-pypi-dependencies.yaml
@@ -26,6 +26,7 @@ modules:
         x-checker-data:
           type: pypi
           name: Pillow
+          is-important: true
 
   - name: python3-psutil
     buildsystem: simple
@@ -176,6 +177,7 @@ modules:
         x-checker-data:
           type: pypi
           name: numpy
+          is-important: true
 
     modules:
       - name: pyproject-metadata

--- a/dependencies/kcc-pypi-dependencies.yaml
+++ b/dependencies/kcc-pypi-dependencies.yaml
@@ -26,7 +26,6 @@ modules:
         x-checker-data:
           type: pypi
           name: Pillow
-          is-important: true
 
   - name: python3-psutil
     buildsystem: simple

--- a/dependencies/kcc-pypi-dependencies.yaml
+++ b/dependencies/kcc-pypi-dependencies.yaml
@@ -177,7 +177,6 @@ modules:
         x-checker-data:
           type: pypi
           name: numpy
-          is-important: true
 
     modules:
       - name: pyproject-metadata

--- a/dependencies/kcc-requirements.txt
+++ b/dependencies/kcc-requirements.txt
@@ -8,4 +8,4 @@ packaging>=23.2
 mozjpeg-lossless-optimization>=1.1.2
 natsort>=8.4.0
 distro>=1.8.0
-numpy>=1.22.4,<2.0.0
+numpy>=1.22.4

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "require-important-update": true
+}


### PR DESCRIPTION
These restrictions seem overly restrictive. being stuck on pillow 12 when 12.1 exists doesn't seem right.

I do not have linux so can't test.

- fix https://github.com/flathub/io.github.ciromattia.kcc/issues/179
- related? https://github.com/ciromattia/kcc/issues/1252

newer pyside versions gives warning when using old numpy. But it still works I think. KCC main repo uses numpy 2 so may be leaving some optimizations on the table. unless its for compatibility?

Since I don't use linux I can't test this change though...

Also, pillow should probably be allowed to run newer versions,

Also pybind might be related idk